### PR TITLE
Endpoint interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "lint:check": "./vendor/bin/ecs",
         "lint:fix": "./vendor/bin/ecs --fix",
         "lint:stan": "./vendor/bin/phpstan",
+        "lint:stan:baseline": "./vendor/bin/phpstan -b",
         "lint:upgrade:check": "vendor/bin/rector process --dry-run",
         "lint:upgrade": "vendor/bin/rector process",
         "lint": "composer lint:upgrade && composer lint:fix && composer lint:stan",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,7 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method WrkFlow\\\\ApiSdkBuilder\\\\AbstractApi\\:\\:getOverrideEndpointClassIfCan\\(\\) should return class\\-string\\<T of WrkFlow\\\\ApiSdkBuilder\\\\Endpoints\\\\AbstractEndpoint\\> but returns class\\-string\\<WrkFlow\\\\ApiSdkBuilder\\\\Endpoints\\\\AbstractEndpoint\\>\\.$#"
-			count: 1
-			path: src/AbstractApi.php
-
-		-
-			message: "#^Method WrkFlow\\\\ApiSdkBuilder\\\\AbstractApi\\:\\:makeEndpoint\\(\\) should return T of WrkFlow\\\\ApiSdkBuilder\\\\Endpoints\\\\AbstractEndpoint but returns WrkFlow\\\\ApiSdkBuilder\\\\Endpoints\\\\AbstractEndpoint\\.$#"
+			message: "#^Method WrkFlow\\\\ApiSdkBuilder\\\\AbstractApi\\:\\:getOverrideEndpointClassIfCan\\(\\) should return class\\-string\\<T of WrkFlow\\\\ApiSdkBuilder\\\\Interfaces\\\\EndpointInterface\\> but returns class\\-string\\<WrkFlow\\\\ApiSdkBuilder\\\\Interfaces\\\\EndpointInterface\\>\\.$#"
 			count: 1
 			path: src/AbstractApi.php
 
@@ -14,4 +9,9 @@ parameters:
 			message: "#^Method WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\Endpoints\\\\Json\\\\JsonEndpoint\\:\\:phpStanShouldReportThis\\(\\) should return WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\Endpoints\\\\Json\\\\JsonResponse but returns WrkFlow\\\\ApiSdkBuilder\\\\Responses\\\\AbstractResponse\\.$#"
 			count: 1
 			path: tests/TestApi/Endpoints/Json/JsonEndpoint.php
+
+		-
+			message: "#^Method WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\TestApi\\:\\:phpStanShouldReportThis\\(\\) should return WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\Endpoints\\\\Json\\\\JsonEndpointInterface but returns WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\Endpoints\\\\EmptyEndpoint\\|WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\Endpoints\\\\Json\\\\JsonEndpointInterface\\.$#"
+			count: 1
+			path: tests/TestApi/TestApi.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10,3 +10,8 @@ parameters:
 			count: 1
 			path: src/AbstractApi.php
 
+		-
+			message: "#^Method WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\Endpoints\\\\Json\\\\JsonEndpoint\\:\\:phpStanShouldReportThis\\(\\) should return WrkFlow\\\\ApiSdkBuilderTests\\\\TestApi\\\\Endpoints\\\\Json\\\\JsonResponse but returns WrkFlow\\\\ApiSdkBuilder\\\\Responses\\\\AbstractResponse\\.$#"
+			count: 1
+			path: tests/TestApi/Endpoints/Json/JsonEndpoint.php
+

--- a/src/Contracts/SDKContainerFactoryContract.php
+++ b/src/Contracts/SDKContainerFactoryContract.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 namespace WrkFlow\ApiSdkBuilder\Contracts;
 
 use Psr\Http\Message\ResponseInterface;
-use WrkFlow\ApiSdkBuilder\Endpoints\AbstractEndpoint;
 use WrkFlow\ApiSdkBuilder\Interfaces\ApiInterface;
+use WrkFlow\ApiSdkBuilder\Interfaces\EndpointInterface;
 use WrkFlow\ApiSdkBuilder\Responses\AbstractResponse;
 use Wrkflow\GetValue\GetValue;
 
 interface SDKContainerFactoryContract
 {
     /**
-     * @template T of AbstractEndpoint
+     * @template T of EndpointInterface
      *
      * @param class-string<T> $endpointClass
      *
      * @return T
      */
-    public function makeEndpoint(ApiInterface $api, string $endpointClass): AbstractEndpoint;
+    public function makeEndpoint(ApiInterface $api, string $endpointClass): EndpointInterface;
 
     /**
      * Dynamically creates an instance of the given class.

--- a/src/Endpoints/AbstractEndpoint.php
+++ b/src/Endpoints/AbstractEndpoint.php
@@ -12,8 +12,10 @@ use Throwable;
 use WrkFlow\ApiSdkBuilder\Contracts\ApiFactoryContract;
 use WrkFlow\ApiSdkBuilder\Entities\EndpointDIEntity;
 use WrkFlow\ApiSdkBuilder\Interfaces\ApiInterface;
+use WrkFlow\ApiSdkBuilder\Interfaces\EndpointInterface;
 use WrkFlow\ApiSdkBuilder\Interfaces\HeadersInterface;
 use WrkFlow\ApiSdkBuilder\Interfaces\OptionsInterface;
+use WrkFlow\ApiSdkBuilder\Log\Contracts\FileLoggerContract;
 use WrkFlow\ApiSdkBuilder\Responses\AbstractResponse;
 
 /**
@@ -22,7 +24,7 @@ use WrkFlow\ApiSdkBuilder\Responses\AbstractResponse;
  *
  * @phpstan-import-type IgnoreLoggersOnExceptionClosure from ApiInterface
  */
-abstract class AbstractEndpoint
+abstract class AbstractEndpoint implements EndpointInterface
 {
     /**
      * @var IgnoreLoggersOnExceptionClosure
@@ -34,10 +36,6 @@ abstract class AbstractEndpoint
     ) {
     }
 
-    /**
-     * Returns a copy of endpoint with ability to prevent loggers from logging failed responses for given
-     * exception.
-     */
     final public function setShouldIgnoreLoggersForExceptions(Closure $closure): static
     {
         $cloned = clone $this;

--- a/src/Endpoints/AbstractEndpoint.php
+++ b/src/Endpoints/AbstractEndpoint.php
@@ -45,6 +45,20 @@ abstract class AbstractEndpoint implements EndpointInterface
         return $cloned;
     }
 
+    final public function dontReportExceptionsToFile(array $exceptions): static
+    {
+        return $this->setShouldIgnoreLoggersForExceptions(static function (Throwable $throwable) use (
+            $exceptions
+        ): array {
+            foreach ($exceptions as $exception) {
+                if ($throwable instanceof $exception) {
+                    return [FileLoggerContract::class];
+                }
+            }
+            return [];
+        });
+    }
+
     final protected function shouldIgnoreLoggersOnException(): ?Closure
     {
         return function (Throwable $throwable): array {
@@ -64,6 +78,7 @@ abstract class AbstractEndpoint implements EndpointInterface
             return $return;
         };
     }
+
 
     /**
      * Appends to base path in uri. Must start with /.

--- a/src/Interfaces/EndpointInterface.php
+++ b/src/Interfaces/EndpointInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilder\Interfaces;
+
+use Closure;
+use Throwable;
+
+/**
+ * Endpoint names that contains all API endpoint methods that sends a request.
+ * This class should be immutable because it is cached.
+ *
+ * @phpstan-import-type IgnoreLoggersOnExceptionClosure from ApiInterface
+ */
+interface EndpointInterface
+{
+    /**
+     * Returns a copy of endpoint with ability to prevent loggers from logging failed responses for given
+     * exception.
+     */
+    public function setShouldIgnoreLoggersForExceptions(Closure $closure): static;
+
+    /**
+     * Returns a copy of endpoint that will not log to file when the request fails with given exception.
+     *
+     * @param array<class-string<Throwable>> $exceptions
+     */
+    public function dontReportExceptionsToFile(array $exceptions): static;
+}

--- a/src/Interfaces/EndpointInterface.php
+++ b/src/Interfaces/EndpointInterface.php
@@ -24,7 +24,7 @@ interface EndpointInterface
     /**
      * Returns a copy of endpoint that will not log to file when the request fails with given exception.
      *
-     * @param array<class-string<Throwable>> $exceptions
+     * @param non-empty-array<class-string<Throwable>> $exceptions
      */
     public function dontReportExceptionsToFile(array $exceptions): static;
 }

--- a/src/Interfaces/EnvironmentOverrideEndpointsInterface.php
+++ b/src/Interfaces/EnvironmentOverrideEndpointsInterface.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace WrkFlow\ApiSdkBuilder\Interfaces;
 
-use WrkFlow\ApiSdkBuilder\Endpoints\AbstractEndpoint;
-
 interface EnvironmentOverrideEndpointsInterface
 {
     /**
-     * @return array<class-string, class-string<AbstractEndpoint>>
+     * @return array<class-string<EndpointInterface>, class-string<EndpointInterface>>
      */
     public function endpoints(): array;
 }

--- a/src/Laravel/Configs/ApiSdkConfig.php
+++ b/src/Laravel/Configs/ApiSdkConfig.php
@@ -23,7 +23,7 @@ class ApiSdkConfig extends AbstractConfig
 
     public function getLogging(): string
     {
-        return $this->config->getRequiredString([self::KeyLogging, self::KeyLoggingType]);
+        return $this->config->getString([self::KeyLogging, self::KeyLoggingType]) ?? '';
     }
 
     public function isTelescopeEnabled(): bool

--- a/src/Laravel/LaravelContainerFactory.php
+++ b/src/Laravel/LaravelContainerFactory.php
@@ -7,9 +7,9 @@ namespace WrkFlow\ApiSdkBuilder\Laravel;
 use Illuminate\Contracts\Container\Container;
 use Psr\Http\Message\ResponseInterface;
 use WrkFlow\ApiSdkBuilder\Contracts\SDKContainerFactoryContract;
-use WrkFlow\ApiSdkBuilder\Endpoints\AbstractEndpoint;
 use WrkFlow\ApiSdkBuilder\Entities\EndpointDIEntity;
 use WrkFlow\ApiSdkBuilder\Interfaces\ApiInterface;
+use WrkFlow\ApiSdkBuilder\Interfaces\EndpointInterface;
 use WrkFlow\ApiSdkBuilder\Responses\AbstractResponse;
 use Wrkflow\GetValue\GetValue;
 
@@ -21,12 +21,12 @@ class LaravelContainerFactory implements SDKContainerFactoryContract
     }
 
     /**
-     * @template T of AbstractEndpoint
+     * @template T of EndpointInterface
      * @param class-string<T> $endpointClass
      *
      * @return T
      */
-    public function makeEndpoint(ApiInterface $api, string $endpointClass): AbstractEndpoint
+    public function makeEndpoint(ApiInterface $api, string $endpointClass): EndpointInterface
     {
         $endpoint = $this->container->make($endpointClass, [
             'di' => $this->container->make(EndpointDIEntity::class, [

--- a/src/Testing/Factories/EndpointDIEntityFactory.php
+++ b/src/Testing/Factories/EndpointDIEntityFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace WrkFlow\ApiSdkBuilder\Testing\Factories;
 
+use WrkFlow\ApiSdkBuilder\Contracts\SendRequestActionContract;
 use WrkFlow\ApiSdkBuilder\Entities\EndpointDIEntity;
 use WrkFlow\ApiSdkBuilder\Interfaces\ApiInterface;
 use WrkFlow\ApiSdkBuilder\Testing\ApiMock;
@@ -13,7 +14,7 @@ final class EndpointDIEntityFactory
 {
     public static function make(
         ApiInterface $api = new ApiMock(),
-        SendTestRequestActionAssert $sendAssert = new SendTestRequestActionAssert()
+        SendRequestActionContract $sendAssert = new SendTestRequestActionAssert()
     ): EndpointDIEntity {
         return new EndpointDIEntity(api: $api, sendRequestAction: $sendAssert);
     }

--- a/src/Testing/Factories/TestSDKContainerFactory.php
+++ b/src/Testing/Factories/TestSDKContainerFactory.php
@@ -8,18 +8,18 @@ use Closure;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Psr\Http\Message\ResponseInterface;
 use WrkFlow\ApiSdkBuilder\Contracts\SDKContainerFactoryContract;
-use WrkFlow\ApiSdkBuilder\Endpoints\AbstractEndpoint;
 use WrkFlow\ApiSdkBuilder\Entities\EndpointDIEntity;
 use WrkFlow\ApiSdkBuilder\Interfaces\ApiInterface;
+use WrkFlow\ApiSdkBuilder\Interfaces\EndpointInterface;
 use WrkFlow\ApiSdkBuilder\Responses\AbstractResponse;
 use Wrkflow\GetValue\GetValue;
 
 final class TestSDKContainerFactory implements SDKContainerFactoryContract
 {
     /**
-     * @param array<class-string<object>, object|Closure():(object|null)>                                                           $makeBindings
+     * @param array<class-string<object>, object|Closure():(object|null)>                                          $makeBindings
      *     A map of closures mapped to a class that should create the instance.
-     * @param array<class-string<AbstractEndpoint>, Closure(EndpointDIEntity):(AbstractEndpoint|null)>                 $makeEndpointBindings
+     * @param array<class-string<EndpointInterface>, Closure(EndpointDIEntity):(EndpointInterface|null)>           $makeEndpointBindings
      *     A map of closures mapped to a class that should create the instance.
      * @param array<class-string<AbstractResponse>, Closure(ResponseInterface, ?GetValue):(AbstractResponse|null)> $makeResponseBindings A map of closures mapped to a class that should create the instance.
      */
@@ -30,14 +30,14 @@ final class TestSDKContainerFactory implements SDKContainerFactoryContract
     ) {
     }
 
-    public function makeEndpoint(ApiInterface $api, string $endpointClass): AbstractEndpoint
+    public function makeEndpoint(ApiInterface $api, string $endpointClass): EndpointInterface
     {
         $result = $this->makeFrom(
             abstract: $endpointClass,
             bindings: $this->makeEndpointBindings,
             makeGiven: static fn (Closure $make) => $make(EndpointDIEntityFactory::make(api: $api)),
         );
-        assert($result instanceof $endpointClass, 'Binding must be instance of ' . AbstractEndpoint::class);
+        assert($result instanceof $endpointClass, 'Binding must be instance of ' . EndpointInterface::class);
         return $result;
     }
 

--- a/tests/Endpoints/AbstractEndpointTest.php
+++ b/tests/Endpoints/AbstractEndpointTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\Endpoints;
+
+use Closure;
+use PHPUnit\Framework\TestCase;
+use WrkFlow\ApiSdkBuilder\Exceptions\ApiException;
+use WrkFlow\ApiSdkBuilder\Log\Contracts\FileLoggerContract;
+use WrkFlow\ApiSdkBuilder\Testing\Exceptions\TestRequestSentException;
+use WrkFlow\ApiSdkBuilder\Testing\Factories\EndpointDIEntityFactory;
+use WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\Json\JsonEndpoint;
+
+final class AbstractEndpointTest extends TestCase
+{
+    /**
+     * @return array<string|int, array{0: Closure(static):void}>
+     */
+    public function dataDontReportToExceptionsToFile(): array
+    {
+        return [
+            'returns empty array if not set' => [
+                static fn (self $self) => $self->assertTestShouldIgnoreLoggers(
+                    assert: new TestShouldIgnoreLoggersSendRequestActionAssert(
+                        testException: new ApiException(),
+                        expectedIgnoreLoggers: [],
+                    ),
+                    onEndpoint: static fn (JsonEndpoint $endpoint) => $endpoint,
+                ),
+            ],
+            'returns empty array if exception does not match' => [
+                static fn (self $self) => $self->assertTestShouldIgnoreLoggers(
+                    assert: new TestShouldIgnoreLoggersSendRequestActionAssert(
+                        testException: new ApiException(),
+                        expectedIgnoreLoggers: [],
+                    ),
+                    onEndpoint: static fn (JsonEndpoint $endpoint) => $endpoint
+                        ->dontReportExceptionsToFile(exceptions: [TestRequestSentException::class]),
+                ),
+            ],
+            'returns empty array if exception matches' => [
+                static fn (self $self) => $self->assertTestShouldIgnoreLoggers(
+                    assert: new TestShouldIgnoreLoggersSendRequestActionAssert(
+                        testException: new ApiException(),
+                        expectedIgnoreLoggers: [FileLoggerContract::class],
+                    ),
+                    onEndpoint: static fn (JsonEndpoint $endpoint) => $endpoint
+                        ->dontReportExceptionsToFile(exceptions: [ApiException::class]),
+                ),
+            ],
+        ];
+    }
+
+
+    /**
+     * @param Closure(static):void $assert
+     *
+     * @dataProvider dataDontReportToExceptionsToFile
+     */
+    public function testDontReportToExceptionsToFile(Closure $assert): void
+    {
+        $assert($this);
+    }
+
+    public function assertTestShouldIgnoreLoggers(
+        TestShouldIgnoreLoggersSendRequestActionAssert $assert,
+        Closure $onEndpoint,
+    ): void {
+        $this->expectException(TestRequestSentException::class);
+
+        $endpoint = new JsonEndpoint(di: EndpointDIEntityFactory::make(sendAssert: $assert));
+        ($onEndpoint($endpoint))
+            ->success();
+    }
+}

--- a/tests/Endpoints/TestShouldIgnoreLoggersSendRequestActionAssert.php
+++ b/tests/Endpoints/TestShouldIgnoreLoggersSendRequestActionAssert.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\Endpoints;
+
+use Closure;
+use PHPUnit\Framework\Assert;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Throwable;
+use WrkFlow\ApiSdkBuilder\Contracts\SendRequestActionContract;
+use WrkFlow\ApiSdkBuilder\Interfaces\ApiInterface;
+use WrkFlow\ApiSdkBuilder\Interfaces\OptionsInterface;
+use WrkFlow\ApiSdkBuilder\Log\Interfaces\ApiLoggerInterface;
+use WrkFlow\ApiSdkBuilder\Responses\AbstractResponse;
+use WrkFlow\ApiSdkBuilder\Testing\Exceptions\TestRequestSentException;
+
+final class TestShouldIgnoreLoggersSendRequestActionAssert implements SendRequestActionContract
+{
+    /**
+     * @param array<class-string<ApiLoggerInterface>> $expectedIgnoreLoggers
+     */
+    public function __construct(
+        private readonly Throwable $testException,
+        private readonly array $expectedIgnoreLoggers,
+    ) {
+    }
+
+    public function execute(
+        ApiInterface $api,
+        RequestInterface $request,
+        string $responseClass,
+        StreamInterface|string|OptionsInterface|null $body = null,
+        array $headers = [],
+        ?int $expectedResponseStatusCode = null,
+        ?ResponseInterface $fakedResponse = null,
+        Closure $shouldIgnoreLoggersOnError = null
+    ): AbstractResponse {
+        Assert::assertNotNull($shouldIgnoreLoggersOnError, 'AbstractEndpoint always builds closure');
+        Assert::assertEquals($this->expectedIgnoreLoggers, $shouldIgnoreLoggersOnError($this->testException));
+
+        throw new TestRequestSentException();
+    }
+}

--- a/tests/Laravel/ApiTestCase.php
+++ b/tests/Laravel/ApiTestCase.php
@@ -7,6 +7,7 @@ namespace WrkFlow\ApiSdkBuilderTests\Laravel;
 use Http\Mock\Client;
 use Psr\Http\Client\ClientInterface;
 use WrkFlow\ApiSdkBuilder\Contracts\ApiFactoryContract;
+use WrkFlow\ApiSdkBuilder\Environments\AbstractEnvironment;
 use WrkFlow\ApiSdkBuilder\Testing\Environments\TestingEnvironment;
 use WrkFlow\ApiSdkBuilderTests\TestApi\TestApi;
 
@@ -21,7 +22,7 @@ abstract class ApiTestCase extends TestCase
         $this->mockBeforeApiFactory();
 
         $this->api = new TestApi(
-            environment: new TestingEnvironment(),
+            environment: $this->createApiEnvironment(),
             factory: $this->make(ApiFactoryContract::class),
         );
     }
@@ -29,6 +30,11 @@ abstract class ApiTestCase extends TestCase
     protected function mockBeforeApiFactory(): void
     {
         $this->useMockApiClient();
+    }
+
+    protected function createApiEnvironment(): AbstractEnvironment
+    {
+        return new TestingEnvironment();
     }
 
     private function useMockApiClient(): void

--- a/tests/Laravel/Configs/ApiSdkConfigLoggingTest.php
+++ b/tests/Laravel/Configs/ApiSdkConfigLoggingTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\Laravel\Configs;
+
+use Closure;
+use Illuminate\Config\Repository;
+use WrkFlow\ApiSdkBuilder\Laravel\Configs\ApiSdkConfig;
+use WrkFlow\ApiSdkBuilderTests\Laravel\TestCase;
+use Wrkflow\GetValue\GetValueFactory;
+
+class ApiSdkConfigLoggingTest extends TestCase
+{
+    /**
+     * @return array<string|int, array{0: Closure(static):void}>
+     */
+    public function data(): array
+    {
+        return [
+            'non empty string' => [
+                static fn (self $self) => $self->assertConfig(set: 'info', expected: 'info'),
+            ],
+            'empty string' => [
+                static fn (self $self) => $self->assertConfig(set: '', expected: ''),
+            ],
+            'null' => [
+                static fn (self $self) => $self->assertConfig(set: null, expected: ''),
+            ],
+        ];
+    }
+
+
+    /**
+     * @param Closure(static):void $assert
+     *
+     * @dataProvider data
+     */
+    public function test(Closure $assert): void
+    {
+        $assert($this);
+    }
+
+    private function assertConfig(?string $set, string $expected): void
+    {
+        $config = new ApiSdkConfig(
+            config: new Repository([
+                'api_sdk' => [
+                    ApiSdkConfig::KeyLogging => [
+                        ApiSdkConfig::KeyLoggingType => $set,
+                    ],
+                ],
+            ]),
+            getValueFactory: new GetValueFactory()
+        );
+        $this->assertEquals($config->getLogging(), $expected);
+    }
+}

--- a/tests/Laravel/TestApiTest.php
+++ b/tests/Laravel/TestApiTest.php
@@ -11,7 +11,8 @@ class TestApiTest extends ApiTestCase
 {
     public function testSuccessPrintsOnlyToLogger(): void
     {
-        $response = $this->api->json()
+        $response = $this->api
+            ->json()
             ->success();
 
         $this->assertEquals(true, $response->success);
@@ -40,6 +41,16 @@ class TestApiTest extends ApiTestCase
         $this->api->json()
             ->failOnStatusCode(statusCode: 500);
     }
+
+    public function testJsonViaInterfaceUsesRealImplementation(): void
+    {
+        $response = $this->api
+            ->jsonViaInterface()
+            ->success();
+
+        $this->assertEquals(true, $response->success);
+    }
+
     protected function mockBeforeApiFactory(): void
     {
         parent::mockBeforeApiFactory();

--- a/tests/Laravel/TestFakeApiTest.php
+++ b/tests/Laravel/TestFakeApiTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\Laravel;
+
+use WrkFlow\ApiSdkBuilder\Environments\AbstractEnvironment;
+use WrkFlow\ApiSdkBuilderTests\TestApi\FakeEnvironment;
+
+class TestFakeApiTest extends ApiTestCase
+{
+    public function testJsonSuccessRealImplementation(): void
+    {
+        $response = $this->api
+            ->json()
+            ->success();
+
+        $this->assertEquals(true, $response->success);
+    }
+
+    public function testJsonViaInterfaceUsesFakeImplementation(): void
+    {
+        $response = $this->api
+            ->jsonViaInterface()
+            ->success();
+
+        $this->assertEquals(false, $response->success);
+    }
+    protected function createApiEnvironment(): AbstractEnvironment
+    {
+        return new FakeEnvironment();
+    }
+}

--- a/tests/TestApi/Endpoints/EmptyEndpoint.php
+++ b/tests/TestApi/Endpoints/EmptyEndpoint.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints;
+
+use WrkFlow\ApiSdkBuilder\Endpoints\AbstractEndpoint;
+
+final class EmptyEndpoint extends AbstractEndpoint
+{
+    protected function basePath(): string
+    {
+        return 'empty';
+    }
+}

--- a/tests/TestApi/Endpoints/Json/FakeJsonEndpoint.php
+++ b/tests/TestApi/Endpoints/Json/FakeJsonEndpoint.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\Json;
+
+use WrkFlow\ApiSdkBuilder\Endpoints\AbstractFakeEndpoint;
+use Wrkflow\GetValue\DataHolders\ArrayData;
+use Wrkflow\GetValue\GetValue;
+
+final class FakeJsonEndpoint extends AbstractFakeEndpoint implements JsonEndpointInterface
+{
+    public function success(): JsonResponse
+    {
+        return $this->makeResponse(
+            responseClass: JsonResponse::class,
+            responseBody: new GetValue(new ArrayData([
+                JsonResponse::KeySuccess => false,
+            ]))
+        );
+    }
+}

--- a/tests/TestApi/Endpoints/Json/JsonEndpoint.php
+++ b/tests/TestApi/Endpoints/Json/JsonEndpoint.php
@@ -52,7 +52,7 @@ class JsonEndpoint extends AbstractTestEndpoint
      */
     public function phpStanShouldReportThis(): JsonResponse
     {
-        return $this->sendGet(responseClass: JsonResponse::class, uri: $this->uri(), headers: $this->headers());
+        return $this->sendGet(responseClass: AbstractResponse::class, uri: $this->uri(), headers: $this->headers());
     }
 
     protected function basePath(): string

--- a/tests/TestApi/Endpoints/Json/JsonEndpoint.php
+++ b/tests/TestApi/Endpoints/Json/JsonEndpoint.php
@@ -8,10 +8,11 @@ use Exception;
 use const true;
 use WrkFlow\ApiSdkBuilder\Headers\JsonHeaders;
 use WrkFlow\ApiSdkBuilder\Interfaces\OptionsInterface;
+use WrkFlow\ApiSdkBuilder\Responses\AbstractResponse;
 use WrkFlow\ApiSdkBuilder\Testing\Responses\JsonResponseMock;
 use WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\AbstractTestEndpoint;
 
-class JsonEndpoint extends AbstractTestEndpoint
+class JsonEndpoint extends AbstractTestEndpoint implements JsonEndpointInterface
 {
     public function success(): JsonResponse
     {
@@ -19,7 +20,6 @@ class JsonEndpoint extends AbstractTestEndpoint
 
         return $this->sendGet(responseClass: JsonResponse::class, uri: $this->uri(), headers: $this->headers());
     }
-
 
     public function store(OptionsInterface $body = null): JsonResponse
     {

--- a/tests/TestApi/Endpoints/Json/JsonEndpointInterface.php
+++ b/tests/TestApi/Endpoints/Json/JsonEndpointInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\Json;
+
+use WrkFlow\ApiSdkBuilder\Interfaces\EndpointInterface;
+
+interface JsonEndpointInterface extends EndpointInterface
+{
+    public function success(): JsonResponse;
+}

--- a/tests/TestApi/FakeEnvironment.php
+++ b/tests/TestApi/FakeEnvironment.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilderTests\TestApi;
+
+use WrkFlow\ApiSdkBuilder\Interfaces\EnvironmentOverrideEndpointsInterface;
+use WrkFlow\ApiSdkBuilder\Testing\Environments\TestingEnvironment;
+use WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\Json\FakeJsonEndpoint;
+use WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\Json\JsonEndpointInterface;
+
+final class FakeEnvironment extends TestingEnvironment implements EnvironmentOverrideEndpointsInterface
+{
+    public function endpoints(): array
+    {
+        return [
+            JsonEndpointInterface::class => FakeJsonEndpoint::class,
+        ];
+    }
+}

--- a/tests/TestApi/TestApi.php
+++ b/tests/TestApi/TestApi.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace WrkFlow\ApiSdkBuilderTests\TestApi;
 
 use WrkFlow\ApiSdkBuilder\AbstractApi;
+use WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\EmptyEndpoint;
 use WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\Json\JsonEndpoint;
+use WrkFlow\ApiSdkBuilderTests\TestApi\Endpoints\Json\JsonEndpointInterface;
 
 class TestApi extends AbstractApi
 {
@@ -17,5 +19,15 @@ class TestApi extends AbstractApi
     public function json(): JsonEndpoint
     {
         return $this->makeEndpoint(JsonEndpoint::class);
+    }
+
+    public function jsonViaInterface(): JsonEndpointInterface
+    {
+        return $this->makeEndpoint(endpoint: JsonEndpointInterface::class, implementation: JsonEndpoint::class);
+    }
+
+    public function phpStanShouldReportThis(): JsonEndpointInterface
+    {
+        return $this->makeEndpoint(endpoint: JsonEndpointInterface::class, implementation: EmptyEndpoint::class);
     }
 }


### PR DESCRIPTION
When using fake overrides you need to pass interface and implementation into `makeEndpoint` method. This changes helps PHPStan to check, if interface is used in the real implementation.


```php
public function unitsAvailabilities(): UnitsAvailabilitiesEndpointInterface
    {
        return $this->makeEndpoint(endpoint: UnitsAvailabilitiesEndpointInterface::class, implementation: UnitsAvailabilitiesEndpoint::class);
    }
```
