### PR TITLE
Add HttpAuthorizationHeader for use in HTTP basic authorization

### DIFF
--- a/src/Headers/HttpAuthorizationHeader.php
+++ b/src/Headers/HttpAuthorizationHeader.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WrkFlow\ApiSdkBuilder\Headers;
+
+use WrkFlow\ApiSdkBuilder\Interfaces\HeadersInterface;
+
+class HttpAuthorizationHeader implements HeadersInterface
+{
+    public function __construct(
+        public readonly string $username,
+        public readonly string $password,
+    ) {
+    }
+
+    public function headers(): array
+    {
+        $key = base64_encode(
+            sprintf(
+                '%s:%s',
+                $this->username,
+                $this->password,
+            ),
+        );
+
+        return [
+            'Authorization' => sprintf('Basic %s', $key),
+        ];
+    }
+}

--- a/src/Headers/HttpAuthorizationHeader.php
+++ b/src/Headers/HttpAuthorizationHeader.php
@@ -9,8 +9,8 @@ use WrkFlow\ApiSdkBuilder\Interfaces\HeadersInterface;
 class HttpAuthorizationHeader implements HeadersInterface
 {
     public function __construct(
-        public readonly string $username,
-        public readonly string $password,
+        #[\SensitiveParameter] public readonly string $username,
+        #[\SensitiveParameter] public readonly string $password,
     ) {
     }
 


### PR DESCRIPTION
@pionl Self-explanatory PR

If you plan to upgrade compatibility to PHP 8.2, you should consider adding `#[\SensitiveParameter]` attribute to `$username` and `$password` so it cannot be visible in stack traces.